### PR TITLE
feat: 新增 chunkedEncodingEnabled 设置

### DIFF
--- a/src/main/java/com/pig4cloud/plugin/oss/OssProperties.java
+++ b/src/main/java/com/pig4cloud/plugin/oss/OssProperties.java
@@ -63,6 +63,12 @@ public class OssProperties {
 	private Boolean pathStyleAccess = true;
 
 	/**
+	 * Option to enable using chunked encoding when signing the request payload
+	 * aliyun 需要关闭
+	 */
+	private Boolean chunkedEncodingEnabled = true;
+
+	/**
 	 * 区域
 	 */
 	private String region;

--- a/src/main/java/com/pig4cloud/plugin/oss/service/OssTemplate.java
+++ b/src/main/java/com/pig4cloud/plugin/oss/service/OssTemplate.java
@@ -327,8 +327,9 @@ public class OssTemplate implements InitializingBean {
 				.region(Region.of(ossProperties.getRegion() != null ? ossProperties.getRegion() : "us-east-1"))
 				.credentialsProvider(StaticCredentialsProvider
 						.create(AwsBasicCredentials.create(ossProperties.getAccessKey(), ossProperties.getSecretKey())))
-				.serviceConfiguration(
-						S3Configuration.builder().pathStyleAccessEnabled(ossProperties.getPathStyleAccess()).build())
+				.serviceConfiguration(S3Configuration.builder()
+							.pathStyleAccessEnabled(ossProperties.getPathStyleAccess())
+							.chunkedEncodingEnabled(ossProperties.getChunkedEncodingEnabled()).build())
 				.build();
 
 		// 创建 S3 Presigner


### PR DESCRIPTION
- 在 OssProperties 中添加 chunkedEncodingEnabled 属性，用于控制是否启用分块编码
- 在OssTemplate 中配置 S3Client时应用该设置
- 默认启用分块编码，但提供配置项允许禁用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configuration option to toggle chunked encoding for the object storage client. This is enabled by default to improve compatibility/performance with S3‑compatible providers. Configure via the application property: oss.chunkedEncodingEnabled.
  - No action required for existing setups; behavior remains compatible by default. If your storage provider requires non‑chunked uploads, set oss.chunkedEncodingEnabled to false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->